### PR TITLE
App demonstration and check

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,7 +1,6 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { Request, Response, NextFunction } from "express";
-import { databaseAuth } from "./database-storage";
 import type { User, LoginRequest, CreateUserRequest } from "@shared/schema";
 
 const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key-change-in-production";
@@ -10,6 +9,30 @@ const BCRYPT_ROUNDS = 12;
 
 export interface AuthRequest extends Request {
   user?: User;
+}
+
+type AuthProvider = {
+  getUserByEmail(email: string): Promise<any | undefined>;
+  getUserById(id: string): Promise<any | undefined>;
+  createUser(user: any): Promise<any>;
+  updateUserLastLogin(id: string): Promise<boolean>;
+};
+
+async function getAuthProvider(): Promise<AuthProvider> {
+  // Production path: use Postgres (if configured).
+  if (process.env.DATABASE_URL) {
+    const { databaseAuth } = await import("./database-storage");
+    return databaseAuth as unknown as AuthProvider;
+  }
+
+  // Demo/dev fallback: use in-memory storage with default demo users.
+  const { storage } = await import("./storage");
+  return {
+    getUserByEmail: (email: string) => storage.getUserByEmail(email),
+    getUserById: (id: string) => storage.getUserById(id),
+    createUser: (user: any) => storage.createUser(user),
+    updateUserLastLogin: (id: string) => storage.updateUserLastLogin(id),
+  };
 }
 
 // Authentication service class
@@ -51,6 +74,7 @@ export class AuthService {
   // Login user - restricted to owner only
   static async login(loginData: LoginRequest): Promise<{ user: User; token: string } | null> {
     try {
+      const authProvider = await getAuthProvider();
       const allowedEmails = [
         'admin@servicepro.com',
         'owner@turnkeypro.com'
@@ -64,7 +88,7 @@ export class AuthService {
         return null;
       }
 
-      const user = await databaseAuth.getUserByEmail(email);
+      const user = await authProvider.getUserByEmail(email);
       if (!user) {
         return null;
       }
@@ -75,7 +99,7 @@ export class AuthService {
       }
 
       // Update last login
-      await databaseAuth.updateUserLastLogin(user.id);
+      await authProvider.updateUserLastLogin(user.id);
 
       const token = this.generateToken(user);
       
@@ -112,6 +136,7 @@ export class AuthService {
 // Middleware to authenticate requests
 export const authenticate = async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
+    const authProvider = await getAuthProvider();
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return res.status(401).json({ message: "No token provided" });
@@ -125,7 +150,7 @@ export const authenticate = async (req: AuthRequest, res: Response, next: NextFu
     }
 
     // Get fresh user data from database
-    const user = await databaseAuth.getUserById(decoded.id);
+    const user = await authProvider.getUserById(decoded.id);
     if (!user || user.status !== "active") {
       return res.status(401).json({ message: "User not found or inactive" });
     }


### PR DESCRIPTION
Allow authentication to fall back to in-memory demo users when `DATABASE_URL` is not set.

The original authentication layer in `server/auth.ts` hard-required `DATABASE_URL` at import time, preventing login for demo users in environments where a database was not configured. This change introduces a `getAuthProvider` function that dynamically selects between `databaseAuth` (if `DATABASE_URL` is present) and the in-memory `storage` (for demo/dev) to ensure admin login works for demos without a full database setup, while maintaining production behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-06cc3ee4-2de8-44a5-8103-5607fd20a3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06cc3ee4-2de8-44a5-8103-5607fd20a3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

